### PR TITLE
Fix/step testing example

### DIFF
--- a/testing/step-testing-example/S02-Load-Data.py
+++ b/testing/step-testing-example/S02-Load-Data.py
@@ -16,3 +16,25 @@ def load_sensor_data(index: int) -> pd.DataFrame:
 # Load data frames and share them for use in the next step
 cd.shared.sensors = [load_sensor_data(index) for index in range(10)]
 cd.shared.df_aerial = pd.read_csv('data/aerial.csv')
+
+# Show the data in the display.
+
+# Ground Sensor Data
+cd.display.markdown(
+    """
+    # Ground Sensor Data
+    """
+)
+
+for idx, sensor_data in enumerate(cd.shared.sensors):
+    cd.display.header('Sensor {}'.format(idx))
+    cd.display.table(sensor_data)
+
+# Aerial Sensor Data
+cd.display.markdown(
+    """
+    # Aerial Sensor Data
+    """
+)
+
+cd.display.table(cd.shared.df_aerial)

--- a/testing/step-testing-example/S03-Plot-Data.py
+++ b/testing/step-testing-example/S03-Plot-Data.py
@@ -19,7 +19,7 @@ def plot_sensor_data(df_sensor: pd.DataFrame):
 
     figure = Figure(
         title='Temperature Data for Sensor #{}'.format(
-            int(df_sensor.ix[0]['sensor_index'])
+            int(df_sensor.iloc[0]['sensor_index'])
         ),
         x_axis_label='Time of Day (Hours)',
         y_axis_label='Temperature (Celsius)'

--- a/testing/step-testing-example/S04-Process-Data.py
+++ b/testing/step-testing-example/S04-Process-Data.py
@@ -35,7 +35,7 @@ def process(df: pd.DataFrame) -> dict:
     data frame.
     """
 
-    sensor_index = df.ix[0]['sensor_index']
+    sensor_index = df.iloc[0]['sensor_index']
 
     swing = int(0.5 * len(df))
     rmse_offsets = np.array(range(-swing, swing + 1))

--- a/testing/step-testing-example/S04-Process-Data.py
+++ b/testing/step-testing-example/S04-Process-Data.py
@@ -34,6 +34,8 @@ def process(df: pd.DataFrame) -> dict:
     dictionary containing those results to be an entry in the results
     data frame.
     """
+    if (df.empty):
+        return
 
     sensor_index = df.iloc[0]['sensor_index']
 

--- a/testing/step-testing-example/step_tests/test_process-data.py
+++ b/testing/step-testing-example/step_tests/test_process-data.py
@@ -48,4 +48,4 @@ class TestProcessData(StepTestCase):
 
         # The lag should be zero because the ground sensor data is identical
         # to the aerial sensor data
-        self.assertEqual(df_results.ix[0]['lag'], 0)
+        self.assertEqual(df_results.iloc[0]['lag'], 0)


### PR DESCRIPTION
Scott,

Here are a few tweaks in step-testing-example:

1. Replacing the deprecated ix method with iloc
2. Fixing a failing test
3. Displaying the aerial and ground data in S02 - just added for my own interest, but not really an issue.

Jim